### PR TITLE
Fix manifest

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,7 @@
 #   include kdiff3
 class kdiff3 {
   package { 'kdiff3':
-    ensure   => installed,
-    source   => 'http://downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.97/kdiff3_0.9.97_MacOS_64bit.dmg?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fkdiff3%2Ffiles%2Flatest%2Fdownload%3Fsource%3Dfiles&ts=1395105090&use_mirror=superb-dca2',
     provider => appdmg,
+    source   => 'http://downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.98/kdiff3-0.9.98-MacOSX-64Bit.dmg',
   }
 }


### PR DESCRIPTION
Fix the following error:

Error: Parameter source failed on File[/opt/boxen/cache/kdiff3.dmg]: Cannot use URLs of type 'http' as source for fileserving at /opt/boxen/repo/shared/kdiff3/manifests/init.pp:10
Wrapped exception:
Cannot use URLs of type 'http' as source for fileserving
